### PR TITLE
Occult crescent

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -210,12 +210,12 @@ public enum CustomComboPreset
 
     [OccultCrescent]
     [ParentCombo(Phantom_Chemist)]
-    [CustomComboInfo("Occult Potion", "Adds Occult Potion into the rotation.", OccultCrescent.JobID)]
+    [CustomComboInfo("Occult Potion", "Adds Occult Potion into the rotation. \nRequires Occult Potions in inventory. \n10k At vendor.", OccultCrescent.JobID)]
     Phantom_Chemist_OccultPotion = 110034,
 
     [OccultCrescent]
     [ParentCombo(Phantom_Chemist)]
-    [CustomComboInfo("Occult Ether", "Adds Occult Ether into the rotation.", OccultCrescent.JobID)]
+    [CustomComboInfo("Occult Ether", "Adds Occult Ether into the rotation.  \nRequires Occult Potions in inventory. \n10k At vendor.", OccultCrescent.JobID)]
     Phantom_Chemist_OccultEther = 110035,
 
     [OccultCrescent]
@@ -225,7 +225,7 @@ public enum CustomComboPreset
 
     [OccultCrescent]
     [ParentCombo(Phantom_Chemist)]
-    [CustomComboInfo("Occult Elixir", "Adds Occult Elixir into the rotation.", OccultCrescent.JobID)]
+    [CustomComboInfo("Occult Elixir", "Adds Occult Elixir into the rotation. \nRequires Occult Elixir in inventory. \n300k At vendor", OccultCrescent.JobID)]
     Phantom_Chemist_OccultElixir = 110037,
 
     [OccultCrescent]

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -139,7 +139,7 @@ internal partial class OccultCrescent
                 return Blessing; //heal
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_Oracle_PhantomJudgment, PhantomJudgment) && HasStatusEffect(Buffs.PredictionOfJudgment))
                 return PhantomJudgment; //damage + heal
-            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Oracle_Cleansing, Cleansing) && HasStatusEffect(Buffs.PredictionOfCleansing) && CanInterruptEnemy())
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Oracle_Cleansing, Cleansing) && HasStatusEffect(Buffs.PredictionOfCleansing)) // removed interupt. it hits 20% harder than Judgement. 120k aoe.
                 return Cleansing; //damage plus interrupt
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_Oracle_Starfall, Starfall) && HasStatusEffect(Buffs.PredictionOfStarfall) && PlayerHealthPercentageHp() <= Config.Phantom_Oracle_Starfall_Health)
                 return Starfall; //damage to targets + 90% total HP damage to self
@@ -199,7 +199,7 @@ internal partial class OccultCrescent
                 return OccultMageMasher; //weaken target's magic attack
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_TimeMage_OccultComet, OccultComet))
                 return OccultComet; //damage
-            if (IsEnabledAndUsable(CustomComboPreset.Phantom_TimeMage_OccultSlowga, OccultSlowga) && !JustUsed(OccultSlowga, 30f)) //shitty hack, fix later
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_TimeMage_OccultSlowga, OccultSlowga) && !HasStatusEffect(Debuffs.Slow, CurrentTarget) && !JustUsed(OccultSlowga, 30f)) //shitty hack, fix later Perhaps a count of casts? it 
                 return OccultSlowga; //aoe slow
         }
         #endregion

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -1,5 +1,7 @@
 ﻿using System.Reflection.Metadata;
+using WrathCombo.CustomComboNS;
 using static WrathCombo.CustomComboNS.Functions.CustomComboFunctions;
+
 
 namespace WrathCombo.Combos.PvE;
 
@@ -54,17 +56,23 @@ internal partial class OccultCrescent
 
         #region Chemist
         //TODO: not sure if this will work tbh
-        if (IsEnabled(CustomComboPreset.Phantom_Chemist) &&
-            CanWeave())
+        if (IsEnabled(CustomComboPreset.Phantom_Chemist))
         {
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_Chemist_Revive, Revive) && TargetIsFriendly() && GetTargetHPPercent() == 0)
-                return Revive; 
-            foreach (var (preset, action) in new[]
-            { (CustomComboPreset.Phantom_Chemist_OccultPotion, OccultPotion),
-            (CustomComboPreset.Phantom_Chemist_OccultEther, OccultEther),
-            (CustomComboPreset.Phantom_Chemist_OccultElixir, OccultElixir), })
-                if (IsEnabledAndUsable(preset, action))
-                    return action;
+                return Revive;
+
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Chemist_OccultPotion, OccultPotion) && PlayerHealthPercentageHp() <= Config.Phantom_Chemist_OccultPotion_Health)
+                return OccultPotion;
+
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Chemist_OccultEther, OccultEther) && LocalPlayer.CurrentMp <= Config.Phantom_Chemist_OccultEther_MP)
+                return OccultEther;
+
+            //foreach (var (preset, action) in new[]
+            //{ (CustomComboPreset.Phantom_Chemist_OccultPotion, OccultPotion),
+            //(CustomComboPreset.Phantom_Chemist_OccultEther, OccultEther),A
+            //(CustomComboPreset.Phantom_Chemist_OccultElixir, OccultElixir), })
+                //if (IsEnabledAndUsable(preset, action))
+                    //return action;
         }
         #endregion
 

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
@@ -21,6 +21,8 @@ internal partial class OccultCrescent
             Phantom_Knight_OccultHeal_Health = new("Phantom_Knight_OccultHeal_Health", 50),
             Phantom_Knight_Pledge_Health = new("Phantom_Knight_Pledge_Health", 50),
             Phantom_Monk_OccultChakra_Health = new("Phantom_Monk_OccultChakra_Health", 29),
+            Phantom_Chemist_OccultPotion_Health = new("Phantom_Chemist_OccultPotion_Health", 50),
+            Phantom_Chemist_OccultEther_MP = new("Phantom_Chemist_OccultEther_MP", 50),
             Phantom_Oracle_Blessing_Health = new("Phantom_Oracle_Blessing_Health", 50),
             Phantom_Oracle_Starfall_Health = new("Phantom_Oracle_Starfall_Health", 100),
             Phantom_Ranger_OccultUnicorn_Health = new("Phantom_Ranger_OccultUnicorn_Health", 50),
@@ -86,6 +88,16 @@ internal partial class OccultCrescent
                 case CustomComboPreset.Phantom_Thief_Steal:
                     UserConfig.DrawSliderInt(1, 50, Phantom_Thief_Steal_Health,
                         "Target HP% to be \nless than or equal to:", 200);
+                    break;
+
+                case CustomComboPreset.Phantom_Chemist_OccultPotion:
+                    UserConfig.DrawSliderInt(1, 100, Phantom_Chemist_OccultPotion_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+
+                case CustomComboPreset.Phantom_Chemist_OccultEther:
+                    UserConfig.DrawSliderInt(1, 10000, Phantom_Chemist_OccultEther_MP,
+                        "Player MP to be \nless than or equal to:", sliderIncrement: SliderIncrements.Hundreds);
                     break;
             }
         }

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
@@ -63,7 +63,7 @@ internal partial class OccultCrescent
                         "Player HP% to be \nless than or equal to:", 200);
                     break;
 
-                case CustomComboPreset.Phantom_Oracle_Cleansing:
+                case CustomComboPreset.Phantom_Oracle_Blessing:
                     UserConfig.DrawSliderInt(1, 100, Phantom_Oracle_Blessing_Health,
                         "Player HP% to be \nless than or equal to:", 200);
                     break;

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
@@ -15,7 +15,7 @@ namespace WrathCombo.Combos.PvE;
 internal partial class OccultCrescent
 {
     internal static bool CanUse(uint action) => HasActionEquipped(action) && IsOffCooldown(action);
-    internal static bool IsEnabledAndUsable(CustomComboPreset preset, uint action) => IsEnabled(preset) && CanUse(action);
+    internal static bool IsEnabledAndUsable(CustomComboPreset preset, uint action) => IsEnabled(preset) && ActionReady(action);
 
     public static ushort
     //Freelancer

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
@@ -53,9 +53,9 @@ internal partial class OccultCrescent
 
     //Time Mage
     OccultSlowga = 41621,
-    OccultComet = 41622,
-    OccultMageMasher = 41623,
-    OccultDispel = 41624,
+    OccultComet = 41623,
+    OccultMageMasher = 41624,
+    OccultDispel = 41622,
     OccultQuick = 41625,
 
     //Chemist

--- a/WrathCombo/Combos/PvE/PCT/PCT.cs
+++ b/WrathCombo/Combos/PvE/PCT/PCT.cs
@@ -238,9 +238,6 @@ internal partial class PCT : Caster
                 return Variant.Rampart;
             #endregion
 
-            if (OccultCrescent.ShouldUsePhantomActions())
-                return OccultCrescent.BestPhantomAction();
-
             #region Prepull
             if ((prepullEnabled && !InCombat()) || (noTargetMotifEnabled && InCombat() && CurrentTarget == null))
             {
@@ -253,8 +250,11 @@ internal partial class PCT : Caster
             }
             #endregion
 
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+
             #region Opener
-           
+
             if (openerEnabled && Opener().FullOpener(ref actionID))
                 return actionID;
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -133,6 +133,10 @@ internal partial class WHM : Healer
             if (actionID is not (Holy or Holy3))
                 return actionID;
 
+            if (OccultCrescent.ShouldUsePhantomActions())
+                return OccultCrescent.BestPhantomAction();
+
+
             #region Swiftcast Opener
 
             if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&


### PR DESCRIPTION
- [x] Chemist potions and ethers set up. Elixir not so much. removed canweave
- [x] fixed oracle blessing slider tied to wrong option, removed canweave. removed interupt from cleansing, it hits harder than judgement
- [x] fixed spell id for time mage. the only class they didn't assign ids in order of acquiring them. added debuff check for slow. left the 30 second for now because of diminishing returns
- [x] added the aoe whm oc action that was missing
- [x] fixed the picto oc action being above the out of combat motifs
- [x] changed the canuse to actionready per tauren so chemist pots work. 