### PR TITLE
Occult crescent

### DIFF
--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent.cs
@@ -16,11 +16,11 @@ internal partial class OccultCrescent
         {
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_Bard_HerosRime, HerosRime))
                 return HerosRime; //burst song
-            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Bard_OffensiveAria, OffensiveAria) && !HasStatusEffect(Buffs.OffensiveAria) && !HasStatusEffect(Buffs.HerosRime))
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Bard_OffensiveAria, OffensiveAria) && !HasStatusEffect(Buffs.OffensiveAria) && !HasStatusEffect(Buffs.HerosRime, anyOwner: true))
                 return OffensiveAria; //off-song
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_Bard_RomeosBallad, RomeosBallad) && CanInterruptEnemy())
                 return RomeosBallad; //interrupt
-            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Bard_MightyMarch, MightyMarch) && !HasStatusEffect(Buffs.MightyMarch))
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Bard_MightyMarch, MightyMarch) && !HasStatusEffect(Buffs.MightyMarch) && PlayerHealthPercentageHp() <= Config.Phantom_Bard_MightyMarch_Health)
                 return MightyMarch; //heal
         }
         #endregion
@@ -39,10 +39,10 @@ internal partial class OccultCrescent
         #region Cannoneer
         if (IsEnabled(CustomComboPreset.Phantom_Cannoneer))
         {
-            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Cannoneer_SilverCannon, SilverCannon) && !HasStatusEffect(Buffs.SilverSickness))
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Cannoneer_SilverCannon, SilverCannon) && !HasStatusEffect(Debuffs.SilverSickness, CurrentTarget))
                 return SilverCannon; //debuff
             //if (IsEnabledAndUsable(CustomComboPreset.Phantom_Cannoneer_HolyCannon, HolyCannon) && TargetIsUndead())
-            //    return HolyCannon; //better on Undead targets
+            //    return HolyCannon; //better on Undead targets____ they dont share a cooldown you fire all the cannons so doesnt really matter if undead. 
 
             foreach (var (preset, action) in new[]
             { (CustomComboPreset.Phantom_Cannoneer_PhantomFire, PhantomFire),
@@ -55,7 +55,7 @@ internal partial class OccultCrescent
         #endregion
 
         #region Chemist
-        //TODO: not sure if this will work tbh
+        //To do, Elixir?
         if (IsEnabled(CustomComboPreset.Phantom_Chemist))
         {
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_Chemist_Revive, Revive) && TargetIsFriendly() && GetTargetHPPercent() == 0)
@@ -66,13 +66,7 @@ internal partial class OccultCrescent
 
             if (IsEnabledAndUsable(CustomComboPreset.Phantom_Chemist_OccultEther, OccultEther) && LocalPlayer.CurrentMp <= Config.Phantom_Chemist_OccultEther_MP)
                 return OccultEther;
-
-            //foreach (var (preset, action) in new[]
-            //{ (CustomComboPreset.Phantom_Chemist_OccultPotion, OccultPotion),
-            //(CustomComboPreset.Phantom_Chemist_OccultEther, OccultEther),A
-            //(CustomComboPreset.Phantom_Chemist_OccultElixir, OccultElixir), })
-                //if (IsEnabledAndUsable(preset, action))
-                    //return action;
+            
         }
         #endregion
 
@@ -157,10 +151,10 @@ internal partial class OccultCrescent
         #region Ranger
         if (IsEnabled(CustomComboPreset.Phantom_Ranger))
         {
-            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Ranger_OccultUnicorn, OccultUnicorn) && CanWeave() && 
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Ranger_OccultUnicorn, OccultUnicorn) && CanWeave() && !HasStatusEffect(Buffs.OccultUnicorn, anyOwner: true) &&
                 PlayerHealthPercentageHp() <= Config.Phantom_Ranger_OccultUnicorn_Health)
                 return OccultUnicorn; //heal
-            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Ranger_PhantomAim, PhantomAim) && CanWeave() &&
+            if (IsEnabledAndUsable(CustomComboPreset.Phantom_Ranger_PhantomAim, PhantomAim) && CanWeave() && !HasStatusEffect(Buffs.PhantomAim, anyOwner:true) &&
                 GetTargetHPPercent() >= Config.Phantom_Ranger_PhantomAim_Stop)
                 return PhantomAim; //damage buff
             //if (IsEnabledAndUsable(CustomComboPreset.Phantom_Ranger_OccultFalcon, OccultFalcon) && CanWeave() && !HasStatusEffect(Buffs.OccultUnicorn)) //TODO: add something for ground targeting? atm needs something like Reaction to work correctly

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Config.cs
@@ -20,6 +20,7 @@ internal partial class OccultCrescent
             Phantom_Knight_Pray_Health = new("Phantom_Knight_Pray_Health", 50),
             Phantom_Knight_OccultHeal_Health = new("Phantom_Knight_OccultHeal_Health", 50),
             Phantom_Knight_Pledge_Health = new("Phantom_Knight_Pledge_Health", 50),
+            Phantom_Bard_MightyMarch_Health = new("Phantom_Bard_MightyMarch_Health", 50),
             Phantom_Monk_OccultChakra_Health = new("Phantom_Monk_OccultChakra_Health", 29),
             Phantom_Chemist_OccultPotion_Health = new("Phantom_Chemist_OccultPotion_Health", 50),
             Phantom_Chemist_OccultEther_MP = new("Phantom_Chemist_OccultEther_MP", 50),
@@ -57,6 +58,10 @@ internal partial class OccultCrescent
                     break;
                 case CustomComboPreset.Phantom_Knight_Pledge:
                     UserConfig.DrawSliderInt(1, 100, Phantom_Knight_Pledge_Health,
+                        "Player HP% to be \nless than or equal to:", 200);
+                    break;
+                case CustomComboPreset.Phantom_Bard_MightyMarch:
+                    UserConfig.DrawSliderInt(1, 100, Phantom_Bard_MightyMarch_Health,
                         "Player HP% to be \nless than or equal to:", 200);
                     break;
 

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
@@ -14,8 +14,6 @@ namespace WrathCombo.Combos.PvE;
 
 internal partial class OccultCrescent
 {
-
-=======
     internal static bool IsEnabledAndUsable(CustomComboPreset preset, uint action) => IsEnabled(preset) && HasActionEquipped(action) && ActionReady(action);
 
     public static ushort

--- a/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
+++ b/WrathCombo/Combos/PvE/Content/OccultCrescent/OccultCrescent_Helper.cs
@@ -135,8 +135,7 @@ internal partial class OccultCrescent
             Suspend = 4258,
             OccultQuick = 4260,
             OccultSprint = 4261,
-            OccultSwift = 4262,
-            SilverSickness = 4264,
+            OccultSwift = 4262,            
             PredictionOfJudgment = 4265,
             PredictionOfCleansing = 4266,
             PredictionOfBlessing = 4267,
@@ -154,8 +153,9 @@ internal partial class OccultCrescent
     {
         public static ushort
 
-            Slow = 3493,
+            Slow = 3493,            
             OccultMageMasher = 4259,
+            SilverSickness = 4264,
             FalsePrediction = 4269,
             WeaponPlifered = 4279;
     }


### PR DESCRIPTION
- [x] Added anyowner to bard Buffs to try and not overlap with party. 
- [x] added mighty march health slider bard, for my war it was a 30k heal followed by a 70k worth of hot over 30 seconds. 
- [x] fixed cannoneer silver sickness to be a debuff, moved the buff code. ID needs checking to be sure. 
- [x] added buff check to ranger skills to prevent group overlap. 
